### PR TITLE
[Refactor]: Full class BinaryReaderEx optimization

### DIFF
--- a/HKX2/BinaryReaderEx.cs
+++ b/HKX2/BinaryReaderEx.cs
@@ -89,7 +89,7 @@ public class BinaryReaderEx
         {
             Span<byte> buf = stackalloc byte[2];
             Stream.ReadExactly(buf);
-            return BigEndian ? BinaryPrimitives.ReadInt16BigEndian(buf) : BinaryPrimitives.ReadInt16LittleEndian(buf);
+            return BinaryPrimitives.ReadInt16BigEndian(buf);
         }
     }
     public ushort ReadUInt16()
@@ -102,7 +102,7 @@ public class BinaryReaderEx
         {
             Span<byte> buf = stackalloc byte[2];
             Stream.ReadExactly(buf);
-            return BigEndian ? BinaryPrimitives.ReadUInt16BigEndian(buf) : BinaryPrimitives.ReadUInt16LittleEndian(buf);
+            return BinaryPrimitives.ReadUInt16BigEndian(buf);
         }
     }
 
@@ -129,7 +129,7 @@ public class BinaryReaderEx
         {
             Span<byte> buf = stackalloc byte[4];
             Stream.ReadExactly(buf);
-            return BigEndian ? BinaryPrimitives.ReadUInt32BigEndian(buf) : BinaryPrimitives.ReadUInt32LittleEndian(buf);
+            return BinaryPrimitives.ReadUInt32BigEndian(buf);
         }
     }
     public long ReadInt64()
@@ -142,7 +142,7 @@ public class BinaryReaderEx
         {
             Span<byte> buf = stackalloc byte[8];
             Stream.ReadExactly(buf);
-            return BigEndian ? BinaryPrimitives.ReadInt64BigEndian(buf) : BinaryPrimitives.ReadInt64LittleEndian(buf);
+            return BinaryPrimitives.ReadInt64BigEndian(buf);
         }
     }
     public ulong ReadUInt64()
@@ -155,7 +155,7 @@ public class BinaryReaderEx
         {
             Span<byte> buf = stackalloc byte[8];
             Stream.ReadExactly(buf);
-            return BigEndian ? BinaryPrimitives.ReadUInt64BigEndian(buf) : BinaryPrimitives.ReadUInt64LittleEndian(buf);
+            return BinaryPrimitives.ReadUInt64BigEndian(buf);
         }
     }
 
@@ -166,25 +166,36 @@ public class BinaryReaderEx
         /// NOTE: C++'s `hkHalf` is the upper 16 bits of `float` and does not follow IEEE 754.
         /// However, this library has already been designed using `System.Half`, so it is necessary not to break compatibility.
         /// Therefore, we should do `bytes` -> `float` -> `half` here to keep compatibility.
-        ///
-        /// - Evidence that `System.Half` is IEEE 754: https://learn.microsoft.com/en-us/dotnet/api/system.half?view=net-8.0#remarks
-        Span<byte> buf = stackalloc byte[2];
-        Stream.ReadExactly(buf);
+        ushort halfBits;
 
-        ushort halfBits = BigEndian ? BinaryPrimitives.ReadUInt16BigEndian(buf)
-                                    : BinaryPrimitives.ReadUInt16LittleEndian(buf);
+        if (!BigEndian)
+        {
+            halfBits = br.ReadUInt16();
+        }
+        else
+        {
+            Span<byte> buf = stackalloc byte[2];
+            Stream.ReadExactly(buf);
+            halfBits = BinaryPrimitives.ReadUInt16BigEndian(buf);
+        }
 
         float floatValue = BitConverter.UInt32BitsToSingle((uint)halfBits << 16);
         return (Half)floatValue;
     }
-
     public float ReadSingle()
     {
-        Span<byte> buf = stackalloc byte[4];
-        Stream.ReadExactly(buf);
+        float val;
 
-        float val = BigEndian ? BinaryPrimitives.ReadSingleBigEndian(buf)
-                              : BinaryPrimitives.ReadSingleLittleEndian(buf);
+        if (!BigEndian)
+        {
+            val = br.ReadSingle();
+        }
+        else
+        {
+            Span<byte> buf = stackalloc byte[4];
+            Stream.ReadExactly(buf);
+            val = BinaryPrimitives.ReadSingleBigEndian(buf);
+        }
 
         // XXX: NaN(0xFFC0000) to 0.
         if (float.IsNaN(val))
@@ -204,7 +215,7 @@ public class BinaryReaderEx
         {
             Span<byte> buf = stackalloc byte[8];
             Stream.ReadExactly(buf);
-            return BigEndian ? BinaryPrimitives.ReadDoubleBigEndian(buf) : BinaryPrimitives.ReadDoubleLittleEndian(buf);
+            return BinaryPrimitives.ReadDoubleBigEndian(buf);
         }
     }
 

--- a/HKX2/BinaryReaderEx.cs
+++ b/HKX2/BinaryReaderEx.cs
@@ -1,388 +1,312 @@
 ﻿using System;
+using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Text;
 
-namespace HKX2E
+namespace HKX2E;
+
+public class BinaryReaderEx
 {
-    public class BinaryReaderEx
+    private readonly Stack<long> steps;
+    private readonly BinaryReader br;
+
+    public BinaryReaderEx(byte[] input) : this(false, false, new MemoryStream(input)) { }
+    public BinaryReaderEx(Stream stream) : this(false, false, stream) { }
+    public BinaryReaderEx(bool bigEndian, bool uSizeLong, byte[] input) : this(bigEndian, uSizeLong, new MemoryStream(input)) { }
+    public BinaryReaderEx(bool bigEndian, bool uSizeLong, Stream stream)
     {
-        private readonly BinaryReader br;
-        private readonly Stack<long> steps;
+        BigEndian = bigEndian;
+        USizeLong = uSizeLong;
+        Stream = stream ?? throw new ArgumentNullException(nameof(stream));
 
-        public BinaryReaderEx(byte[] input) : this(false, false, input)
+        br = new BinaryReader(stream, Encoding.ASCII, leaveOpen: true);
+        steps = new Stack<long>();
+    }
+
+    public bool BigEndian { get; set; }
+    public bool USizeLong { get; }
+    public Stream Stream { get; }
+
+    public long Position { get => Stream.Position; set => Stream.Position = value; }
+    public long Length => Stream.Length;
+
+    public byte[] ReadBytes(int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        if (count == 0) return Array.Empty<byte>();
+
+        var buffer = new byte[count];
+        Stream.ReadExactly(buffer);
+        return buffer;
+    }
+
+
+    public void StepIn(long offset) { steps.Push(Stream.Position); Stream.Position = offset; }
+
+    public void StepOut()
+    {
+        if (steps.Count == 0) throw new InvalidOperationException("Reader is already stepped all the way out.");
+        Stream.Position = steps.Pop();
+    }
+
+    public void Pad(int align)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(align);
+
+        long mod = Stream.Position % align;
+        if (mod > 0) Stream.Position += align - mod;
+    }
+
+    private static T AssertValue<T>(T value, string typeName, string valueFormat, T[] options) where T : IEquatable<T>
+    {
+        foreach (var option in options)
+            if (value.Equals(option)) return value;
+        var strValue = string.Format(valueFormat, value);
+        var strOptions = string.Join(", ", options.Select(o => string.Format(valueFormat, o)));
+
+        throw new InvalidDataException($"Read {typeName}: {strValue} | Expected: {strOptions}");
+    }
+
+    #region Read Methods
+
+    public bool ReadBoolean() => br.ReadBoolean();
+
+    public byte ReadByte() => br.ReadByte();
+
+    public sbyte ReadSByte() => br.ReadSByte();
+
+    public short ReadInt16()
+    {
+        if (!BigEndian)
         {
-        }
-
-        public BinaryReaderEx(Stream stream) : this(false, false, stream)
-        {
-        }
-
-        public BinaryReaderEx(bool bigEndian, bool uSizeLong, byte[] input) : this(bigEndian, uSizeLong,
-            new MemoryStream(input))
-        {
-        }
-
-        public BinaryReaderEx(bool bigEndian, bool uSizeLong, Stream stream)
-        {
-            BigEndian = bigEndian;
-            USizeLong = uSizeLong;
-            steps = new Stack<long>();
-            Stream = stream;
-            br = new BinaryReader(stream);
-        }
-
-        public bool BigEndian { get; set; }
-
-        public bool USizeLong { get; }
-
-        public Stream Stream { get; }
-
-        public long Position
-        {
-            get => Stream.Position;
-            set => Stream.Position = value;
-        }
-
-        public long Length => Stream.Length;
-
-
-        public byte[] ReadBytes(int count)
-        {
-            var result = br.ReadBytes(count);
-            if (result.Length != count)
-                throw new EndOfStreamException("Remaining size of stream was smaller than requested number of bytes.");
-            return result;
-        }
-
-        private byte[] ReadReversedBytes(int length)
-        {
-            var bytes = ReadBytes(length);
-            Array.Reverse(bytes);
-            return bytes;
-        }
-
-        private T AssertValue<T>(T value, string typeName, string valueFormat, T[] options) where T : IEquatable<T>
-        {
-            foreach (var option in options)
-                if (value.Equals(option))
-                    return value;
-
-            var strValue = string.Format(valueFormat, value);
-            var strOptions = string.Join(", ", options.Select(o => string.Format(valueFormat, o)));
-            throw new InvalidDataException(
-                $"Read {typeName}: {strValue} | Expected: {strOptions} | Ending position: 0x{Position:X}");
-        }
-
-        public void StepIn(long offset)
-        {
-            steps.Push(Stream.Position);
-            Stream.Position = offset;
-        }
-
-        public void StepOut()
-        {
-            if (steps.Count == 0)
-                throw new InvalidOperationException("Reader is already stepped all the way out.");
-
-            Stream.Position = steps.Pop();
-        }
-
-        public void Pad(int align)
-        {
-            if (Stream.Position % align > 0)
-                Stream.Position += align - Stream.Position % align;
-        }
-
-        public ulong ReadUSize()
-        {
-            if (USizeLong)
-                return ReadUInt64();
-            return ReadUInt32();
-        }
-
-        public ulong AssertUSize(params ulong[] options)
-        {
-            return AssertValue(ReadUSize(), USizeLong ? "USize64" : "USize32", "0x{0:X}", options);
-        }
-
-        #region Other
-
-        public Vector4 ReadVector4()
-        {
-            var x = ReadSingle();
-            var y = ReadSingle();
-            var z = ReadSingle();
-            var w = ReadSingle();
-            return new Vector4(x, y, z, w);
-        }
-
-        #endregion
-
-        #region Boolean
-
-        public bool ReadBoolean()
-        {
-            var b = ReadByte();
-
-            return b switch
-            {
-                0 => false,
-                1 => true,
-                _ => throw new InvalidDataException($"ReadBoolean encountered non-boolean value: 0x{b:X2}")
-            };
-        }
-
-        public bool AssertBoolean(bool option)
-        {
-            return AssertValue(ReadBoolean(), "Boolean", "{0}", new[] { option });
-        }
-
-        #endregion
-
-        #region SByte
-
-        public sbyte ReadSByte()
-        {
-            return (sbyte)ReadByte();
-        }
-
-        public sbyte AssertSByte(params sbyte[] options)
-        {
-            return AssertValue(ReadSByte(), "SByte", "0x{0:X}", options);
-        }
-
-        #endregion
-
-        #region Byte
-
-        public byte ReadByte()
-        {
-            return ReadBytes(1)[0];
-        }
-
-        public byte AssertByte(params byte[] options)
-        {
-            return AssertValue(ReadByte(), "Byte", "0x{0:X}", options);
-        }
-
-        #endregion
-
-        #region Int16
-
-        public short ReadInt16()
-        {
-            if (BigEndian)
-                return BitConverter.ToInt16(ReadReversedBytes(2));
             return br.ReadInt16();
         }
-
-        public short AssertInt16(params short[] options)
+        else
         {
-            return AssertValue(ReadInt16(), "Int16", "0x{0:X}", options);
+            Span<byte> buf = stackalloc byte[2];
+            Stream.ReadExactly(buf);
+            return BigEndian ? BinaryPrimitives.ReadInt16BigEndian(buf) : BinaryPrimitives.ReadInt16LittleEndian(buf);
         }
-
-        #endregion
-
-        #region UInt16
-
-        public ushort ReadUInt16()
+    }
+    public ushort ReadUInt16()
+    {
+        if (!BigEndian)
         {
-            if (BigEndian)
-                return BitConverter.ToUInt16(ReadReversedBytes(2), 0);
             return br.ReadUInt16();
         }
-
-        public ushort AssertUInt16(params ushort[] options)
+        else
         {
-            return AssertValue(ReadUInt16(), "UInt16", "0x{0:X}", options);
+            Span<byte> buf = stackalloc byte[2];
+            Stream.ReadExactly(buf);
+            return BigEndian ? BinaryPrimitives.ReadUInt16BigEndian(buf) : BinaryPrimitives.ReadUInt16LittleEndian(buf);
         }
+    }
 
-        #endregion
-
-        #region Int32
-
-        public int ReadInt32()
+    public int ReadInt32()
+    {
+        if (!BigEndian)
         {
-            if (BigEndian)
-                return BitConverter.ToInt32(ReadReversedBytes(4), 0);
             return br.ReadInt32();
         }
-
-        public int AssertInt32(params int[] options)
+        else
         {
-            return AssertValue(ReadInt32(), "Int32", "0x{0:X}", options);
+            Span<byte> buf = stackalloc byte[4];
+            Stream.ReadExactly(buf);
+            return BinaryPrimitives.ReadInt32BigEndian(buf);
         }
-
-        #endregion
-
-        #region UInt32
-
-        public uint ReadUInt32()
+    }
+    public uint ReadUInt32()
+    {
+        if (!BigEndian)
         {
-            if (BigEndian)
-                return BitConverter.ToUInt32(ReadReversedBytes(4), 0);
             return br.ReadUInt32();
         }
-
-        public uint AssertUInt32(params uint[] options)
+        else
         {
-            return AssertValue(ReadUInt32(), "UInt32", "0x{0:X}", options);
+            Span<byte> buf = stackalloc byte[4];
+            Stream.ReadExactly(buf);
+            return BigEndian ? BinaryPrimitives.ReadUInt32BigEndian(buf) : BinaryPrimitives.ReadUInt32LittleEndian(buf);
         }
-
-        #endregion
-
-        #region Int64
-
-        public long ReadInt64()
+    }
+    public long ReadInt64()
+    {
+        if (!BigEndian)
         {
-            if (BigEndian)
-                return BitConverter.ToInt64(ReadReversedBytes(8), 0);
             return br.ReadInt64();
         }
-
-        public long AssertInt64(params long[] options)
+        else
         {
-            return AssertValue(ReadInt64(), "Int64", "0x{0:X}", options);
+            Span<byte> buf = stackalloc byte[8];
+            Stream.ReadExactly(buf);
+            return BigEndian ? BinaryPrimitives.ReadInt64BigEndian(buf) : BinaryPrimitives.ReadInt64LittleEndian(buf);
         }
-
-        #endregion
-
-        #region UInt64
-
-        public ulong ReadUInt64()
+    }
+    public ulong ReadUInt64()
+    {
+        if (!BigEndian)
         {
-            if (BigEndian)
-                return BitConverter.ToUInt64(ReadReversedBytes(8), 0);
             return br.ReadUInt64();
         }
-
-        public ulong AssertUInt64(params ulong[] options)
+        else
         {
-            return AssertValue(ReadUInt64(), "UInt64", "0x{0:X}", options);
+            Span<byte> buf = stackalloc byte[8];
+            Stream.ReadExactly(buf);
+            return BigEndian ? BinaryPrimitives.ReadUInt64BigEndian(buf) : BinaryPrimitives.ReadUInt64LittleEndian(buf);
         }
+    }
 
-        #endregion
+    public ulong ReadUSize() => USizeLong ? ReadUInt64() : ReadUInt32();
 
-        #region Half
+    public Half ReadHalf()
+    {
+        /// NOTE: C++'s `hkHalf` is the upper 16 bits of `float` and does not follow IEEE 754.
+        /// However, this library has already been designed using `System.Half`, so it is necessary not to break compatibility.
+        /// Therefore, we should do `bytes` -> `float` -> `half` here to keep compatibility.
+        ///
+        /// - Evidence that `System.Half` is IEEE 754: https://learn.microsoft.com/en-us/dotnet/api/system.half?view=net-8.0#remarks
+        Span<byte> buf = stackalloc byte[2];
+        Stream.ReadExactly(buf);
 
-        public Half ReadHalf()
+        ushort halfBits = BigEndian ? BinaryPrimitives.ReadUInt16BigEndian(buf)
+                                    : BinaryPrimitives.ReadUInt16LittleEndian(buf);
+
+        float floatValue = BitConverter.UInt32BitsToSingle((uint)halfBits << 16);
+        return (Half)floatValue;
+    }
+
+    public float ReadSingle()
+    {
+        Span<byte> buf = stackalloc byte[4];
+        Stream.ReadExactly(buf);
+
+        float val = BigEndian ? BinaryPrimitives.ReadSingleBigEndian(buf)
+                              : BinaryPrimitives.ReadSingleLittleEndian(buf);
+
+        // XXX: NaN(0xFFC0000) to 0.
+        if (float.IsNaN(val))
+            return 0f;
+
+        // XXX: round? to 6 decimal
+        return (float)Math.Round(val, 6);
+    }
+
+    public double ReadDouble()
+    {
+        if (!BigEndian)
         {
-            /// NOTE: C++'s `hkHalf` is the upper 16 bits of `float` and does not follow IEEE 754.
-            /// However, this library has already been designed using `System.Half`, so it is necessary not to break compatibility.
-            /// Therefore, we should do `bytes` -> `float` -> `half` here to keep compatibility.
-            ///
-            /// - Evidence that `System.Half` is IEEE 754: https://learn.microsoft.com/en-us/dotnet/api/system.half?view=net-8.0#remarks
-            byte[] byteArray;
-
-            if (BigEndian)
-                byteArray = ReadReversedBytes(2);
-            else
-                byteArray = ReadBytes(2);
-
-            ushort halfBits = BitConverter.ToUInt16(byteArray, 0);
-            float floatValue = BitConverter.UInt32BitsToSingle((uint)halfBits << 16);
-            return (Half)floatValue;
-        }
-
-        public Half AssertHalf(params Half[] options)
-        {
-            return AssertValue(ReadHalf(), "Half", "{0}", options);
-        }
-
-        #endregion
-
-        #region Single
-
-        private float RoundSignle(float d)
-        {
-            var s = Math.Round(d - Math.Truncate(d), 6).ToString("F6");
-            s = s[(s.IndexOf(".") + 1)..];
-            s = $"{Math.Truncate(d):F0}.{s}";
-            return float.Parse(s);
-        }
-
-        public float ReadSingle()
-        {
-            // XXX: NaN(0xFFC0000) to 0.
-            // XXX: round? to 6 deciaml
-            if (BigEndian)
-            {
-                var revVal = BitConverter.ToSingle(ReadReversedBytes(4), 0);
-                return float.IsNaN(revVal) ? 0 : (float)Math.Round(revVal, 6);
-            }
-            var val = br.ReadSingle();
-            return float.IsNaN(val) ? 0 : (float)Math.Round(val, 6);
-        }
-
-        public float AssertSingle(params float[] options)
-        {
-            return AssertValue(ReadSingle(), "Single", "{0}", options);
-        }
-
-        #endregion
-
-        #region Double
-
-        public double ReadDouble()
-        {
-            if (BigEndian)
-                return BitConverter.ToDouble(ReadReversedBytes(8), 0);
             return br.ReadDouble();
         }
-
-        public double AssertDouble(params double[] options)
+        else
         {
-            return AssertValue(ReadDouble(), "Double", "{0}", options);
+            Span<byte> buf = stackalloc byte[8];
+            Stream.ReadExactly(buf);
+            return BigEndian ? BinaryPrimitives.ReadDoubleBigEndian(buf) : BinaryPrimitives.ReadDoubleLittleEndian(buf);
         }
-
-        #endregion
-
-        #region String
-
-        private string ReadChars(Encoding encoding, int length)
-        {
-            var bytes = ReadBytes(length);
-            return encoding.GetString(bytes);
-        }
-
-        private string ReadCharsTerminated(Encoding encoding)
-        {
-            var bytes = new List<byte>();
-
-            var b = ReadByte();
-            while (b != 0)
-            {
-                bytes.Add(b);
-                b = ReadByte();
-            }
-
-            return encoding.GetString(bytes.ToArray());
-        }
-
-        public string ReadASCII()
-        {
-            return ReadCharsTerminated(Encoding.ASCII);
-        }
-
-        public string ReadASCII(int length)
-        {
-            return ReadChars(Encoding.ASCII, length);
-        }
-
-        public string ReadFixStr(int size)
-        {
-            var bytes = ReadBytes(size);
-            int terminator;
-            for (terminator = 0; terminator < size; terminator++)
-                if (bytes[terminator] == 0)
-                    break;
-
-            return Encoding.ASCII.GetString(bytes, 0, terminator);
-        }
-
-        #endregion
     }
+
+    private string ReadChars(Encoding encoding, int length)
+    {
+        if (length <= 0) return string.Empty;
+        byte[] rented = ArrayPool<byte>.Shared.Rent(length);
+        try
+        {
+            var span = rented.AsSpan(0, length);
+            Stream.ReadExactly(span);
+            return encoding.GetString(span);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    private string ReadCharsTerminated(Encoding encoding)
+    {
+        var bytes = new List<byte>();
+        int b;
+        while ((b = Stream.ReadByte()) != 0 && b != -1)
+        {
+            bytes.Add((byte)b);
+        }
+        return encoding.GetString(bytes.ToArray());
+    }
+
+    public string ReadASCII() => ReadCharsTerminated(Encoding.ASCII);
+    public string ReadASCII(int length) => ReadChars(Encoding.ASCII, length);
+
+    public string ReadFixStr(int size)
+    {
+        if (size <= 0) return string.Empty;
+        byte[] rented = ArrayPool<byte>.Shared.Rent(size);
+        try
+        {
+            var span = rented.AsSpan(0, size);
+            Stream.ReadExactly(span);
+            int term = span.IndexOf((byte)0);
+            int len = term >= 0 ? term : size;
+            return Encoding.ASCII.GetString(span.Slice(0, len));
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    public Vector4 ReadVector4()
+    {
+        var x = ReadSingle();
+        var y = ReadSingle();
+        var z = ReadSingle();
+        var w = ReadSingle();
+        return new Vector4(x, y, z, w);
+    }
+
+    #endregion
+
+    #region Assert Methods
+
+    public ulong AssertUSize(params ulong[] options) =>
+        AssertValue(ReadUSize(), USizeLong ? "USize64" : "USize32", "0x{0:X}", options);
+
+    public bool AssertBoolean(bool option) =>
+        AssertValue(ReadBoolean(), "Boolean", "{0}", [option]);
+
+    public sbyte AssertSByte(params sbyte[] options) =>
+        AssertValue(ReadSByte(), "SByte", "0x{0:X}", options);
+
+    public byte AssertByte(params byte[] options) =>
+        AssertValue(ReadByte(), "Byte", "0x{0:X}", options);
+
+    public short AssertInt16(params short[] options) =>
+        AssertValue(ReadInt16(), "Int16", "0x{0:X}", options);
+
+    public ushort AssertUInt16(params ushort[] options) =>
+        AssertValue(ReadUInt16(), "UInt16", "0x{0:X}", options);
+
+    public int AssertInt32(params int[] options) =>
+        AssertValue(ReadInt32(), "Int32", "0x{0:X}", options);
+
+    public uint AssertUInt32(params uint[] options) =>
+        AssertValue(ReadUInt32(), "UInt32", "0x{0:X}", options);
+
+    public long AssertInt64(params long[] options) =>
+        AssertValue(ReadInt64(), "Int64", "0x{0:X}", options);
+
+    public ulong AssertUInt64(params ulong[] options) =>
+        AssertValue(ReadUInt64(), "UInt64", "0x{0:X}", options);
+
+    public Half AssertHalf(params Half[] options) =>
+        AssertValue(ReadHalf(), "Half", "{0}", options);
+
+    public float AssertSingle(params float[] options) =>
+        AssertValue(ReadSingle(), "Single", "{0}", options);
+
+    public double AssertDouble(params double[] options) =>
+        AssertValue(ReadDouble(), "Double", "{0}", options);
+
+    #endregion
 }


### PR DESCRIPTION
This PR optimizes the logic of the methods and introduces the use of Span. Instead of creating arrays on the managed heap, a temporary buffer for bytes is allocated on the stack. This completely eliminates the memory allocation for reading short, int, float, etc. Also improved the native implementation of reading bytes with the new `ReadExactly()` API. Replaces the old "read and check the length" logic. This method guarantees that the exact number of bytes requested will be read, or an exception will be thrown, making the code more reliable and concise. All the main optimization is to reduce memory load and the number of GC calls. The changes were inspired by the source code from BinaryReader itself: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/IO/BinaryReader.cs